### PR TITLE
Fix RuntimeError when computing metrics

### DIFF
--- a/lighter/system.py
+++ b/lighter/system.py
@@ -174,6 +174,10 @@ class System(pl.LightningModule):
             metrics = getattr(self.metrics, self.mode)
             if metrics is not None:
                 adapters = getattr(self.adapters, self.mode)
+                try:
+                    metrics = metrics.to(input.device)
+                except AttributeError:
+                    pass
                 metrics = adapters.metrics(metrics, input, target, pred)
         return metrics
 


### PR DESCRIPTION
I was getting the following error:

```python-traceback
RuntimeError: Encountered different devices in metric calculation (see stacktrace for details). This could be due to the metric class not being on the same device as input. Instead of
`metric=MulticlassAccuracy(...)` try to do `metric=MulticlassAccuracy(...).to(device)` where device corresponds to the device of the input.
```